### PR TITLE
remove duplicate Sign Up link

### DIFF
--- a/src/components/global/Navbar.tsx
+++ b/src/components/global/Navbar.tsx
@@ -80,15 +80,16 @@ const Navbar = () => {
           <li>
             <Link to="/about">About</Link>
           </li>
-          <li>
-            <Link to="/signup">Sign Up</Link>
-          </li>
-          {!token && (
-            <li>
-              <Link to="/signup">Sign Up</Link>
-            </li>
-          )}
-          {token && (
+          {!token ? (
+            <>
+              <li>
+                <Link to="/login">Log In</Link>
+              </li>
+              <li>
+                <Link to="/signup">Sign Up</Link>
+              </li>
+            </>
+          ) : (
             <li>
               <Link
                 to="/"


### PR DESCRIPTION
- Removed an unconditional Sign Up link to prevent it from rendering twice.
- Updated conditional rendering to show both "Log In" and "Sign Up" when the user is not logged in.
- "Logout" is still displayed for logged-in users.